### PR TITLE
Applying Nix best practices and useful paradigms

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# try to use flake initially, fallback to non-flake use otherwise
+if nix flake show &> /dev/null; then
+  use flake
+else
+  use nix
+fi

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/flake.lock
+++ b/flake.lock
@@ -1,6 +1,161 @@
 {
   "nodes": {
+    "ci-public": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699519620,
+        "narHash": "sha256-1pB3xE8lKofG2lggKqCIgHnggnGEp2xNEnbbKvzoU2M=",
+        "owner": "tiiuae",
+        "repo": "ci-public",
+        "rev": "b0c589cdd950b947cced272ae10def85d81779b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tiiuae",
+        "repo": "ci-public",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688025799,
+        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688025799,
+        "narHash": "sha256-ktpB4dRtnksm9F5WawoIkEneh1nrEvuxb5lJFt1iOyw=",
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "rev": "8bf105319d44f6b9f0d764efa4fdef9f1cc9ba1c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-root": {
+      "locked": {
+        "lastModified": 1692742795,
+        "narHash": "sha256-f+Y0YhVCIJ06LemO+3Xx00lIcqQxSKJHXT/yk1RTKxw=",
+        "owner": "srid",
+        "repo": "flake-root",
+        "rev": "d9a70d9c7a5fd7f3258ccf48da9335e9b47c3937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "srid",
+        "repo": "flake-root",
+        "type": "github"
+      }
+    },
+    "nix-fast-build": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": [
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1699459690,
+        "narHash": "sha256-0qS0X7KaQ6fjNG3UexNFK1Up9esZEGjevVHHbxjuk9E=",
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "rev": "77c764981a9738aadb55b80e3e0891e6f2572477",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-fast-build",
+        "type": "github"
+      }
+    },
+    "nix-visualize": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687577587,
+        "narHash": "sha256-Z1r8XHszoUnQinl63yXvQG6Czp5HnYNG37AY+EEiT4w=",
+        "owner": "craigmbooth",
+        "repo": "nix-visualize",
+        "rev": "cafaba50cd63ba9c759c56af71fd0d22fd60a548",
+        "type": "github"
+      },
+      "original": {
+        "owner": "craigmbooth",
+        "repo": "nix-visualize",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
+      "locked": {
+        "lastModified": 1698890957,
+        "narHash": "sha256-DJ+SppjpPBoJr0Aro9TAcP3sxApCSieY6BYBCoWGUX8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c082856b850ec60cda9f0a0db2bc7bd8900d708c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
       "locked": {
         "lastModified": 1693844670,
         "narHash": "sha256-t69F2nBB8DNQUWHD809oJZJVE+23XBrth4QZuVd6IE0=",
@@ -18,7 +173,86 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "ci-public": "ci-public",
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "nix-fast-build": "nix-fast-build",
+        "nixpkgs": "nixpkgs_2",
+        "sbomnix": "sbomnix",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "sbomnix": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "flake-root": [
+          "flake-root"
+        ],
+        "nix-fast-build": [
+          "nix-fast-build"
+        ],
+        "nix-visualize": "nix-visualize",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "treefmt-nix": [
+          "treefmt-nix"
+        ],
+        "vulnix": "vulnix"
+      },
+      "locked": {
+        "lastModified": 1699872094,
+        "narHash": "sha256-SqBSwBo9kx8uxuJLDpP0BxZ5/g5zyP1CZNziW6Z4Elc=",
+        "owner": "brianmcgee",
+        "repo": "sbomnix",
+        "rev": "c6aa077337f72bf506760392cfb3f4b74758ade5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "brianmcgee",
+        "ref": "fix/repolocy_cli-reference",
+        "repo": "sbomnix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1699656829,
+        "narHash": "sha256-aqz/YOrllfsUF88FG+xhm+ywB+KxSE8FpPWSY6QnDvY=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "8b25ad882a6fc9905fa515c2b61d196b42ca79a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "vulnix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1676379453,
+        "narHash": "sha256-KXvmnaMjv//zd4aSwu4qmbon1Iyzdod6CPms7LIxeVU=",
+        "owner": "henrirosten",
+        "repo": "vulnix",
+        "rev": "ad28b2924027a44a9b81493a0f9de1b0e8641005",
+        "type": "github"
+      },
+      "original": {
+        "owner": "henrirosten",
+        "repo": "vulnix",
+        "type": "github"
       }
     }
   },

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{lib, ...}: {
+  perSystem = {
+    self',
+    pkgs,
+    ...
+  }: {
+    checks =
+      {
+        # checks that copyright headers are compliant
+        # todo this could be moved into a shared flake
+        reuse =
+          pkgs.runCommandLocal "reuse-lint" {
+            buildInputs = [pkgs.reuse];
+          } ''
+            cd ${../.}
+            reuse lint
+            touch $out
+          '';
+      }
+      //
+      # merge in the package derivations to force a build of all packages during a `nix flake check`
+      (with lib; mapAttrs' (n: nameValuePair "package-${n}") self'.packages);
+  };
+}

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,14 +1,11 @@
 # SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
 #
 # SPDX-License-Identifier: Apache-2.0
-
-venv/
-*.egg-info/
-.eggs/
-__pycache__/
-*.py[cod]
-*.sqlite
-/*.log
-result
-.direnv
-.idea
+{
+  imports = [
+    ./checks.nix
+    ./devshell.nix
+    ./packages.nix
+    ./treefmt.nix
+  ];
+}

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{
+  perSystem = {
+    pkgs,
+    inputs',
+    self',
+    ...
+  }: {
+    devShells.default = let
+      pp = pkgs.python3Packages;
+    in
+      pkgs.mkShell rec {
+        name = "ghafscan-dev-shell";
+
+        buildInputs =
+          (with pkgs; [
+            coreutils
+            curl
+            gnugrep
+            gnused
+            graphviz
+            grype
+            gzip
+            nix
+            reuse
+          ])
+          ++ [
+            self'.packages.csvdiff
+            # bring in vulnxscan from sbomnix
+            inputs'.sbomnix.packages.default
+          ]
+          ++ (with pp; [
+            black
+            colorlog
+            gitpython
+            pandas
+            pycodestyle
+            pylint
+            pytest
+            tabulate
+            venvShellHook
+          ])
+          ++ [inputs'.nix-fast-build.packages.default];
+
+        venvDir = "venv";
+        postShellHook = ''
+          export PYTHONPATH="$PWD/src:$PYTHONPATH"
+
+          # https://github.com/NixOS/nix/issues/1009:
+          export TMPDIR="/tmp"
+
+          # Enter python development environment
+          make install-dev
+        '';
+      };
+  };
+}

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{inputs, ...}: {
+  perSystem = {
+    inputs',
+    pkgs,
+    lib,
+    ...
+  }: let
+    pp = pkgs.python3Packages;
+  in {
+    packages = rec {
+      default = ghafscan;
+
+      csvdiff = (import "${inputs.ci-public}/csvdiff") {inherit pkgs;};
+
+      ghafscan = pp.buildPythonPackage rec {
+        pname = "ghafscan";
+        version = pkgs.lib.removeSuffix "\n" (builtins.readFile ../VERSION);
+        format = "setuptools";
+
+        src = lib.cleanSource ../.;
+
+        pythonImportsCheck = ["ghafscan"];
+
+        propagatedBuildInputs =
+          [
+            pkgs.reuse
+            csvdiff
+            # we need vulnxscan from sbombnix
+            inputs'.sbomnix.packages.default
+          ]
+          ++ (with pp; [
+            colorlog
+            gitpython
+            pandas
+            tabulate
+          ]);
+      };
+    };
+  };
+}

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2023 Technology Innovation Institute (TII)
+#
+# SPDX-License-Identifier: Apache-2.0
+{inputs, ...}: {
+  imports = with inputs; [
+    flake-root.flakeModule
+    treefmt-nix.flakeModule
+  ];
+  perSystem = {
+    config,
+    pkgs,
+    ...
+  }: {
+    treefmt.config = {
+      package = pkgs.treefmt;
+      inherit (config.flake-root) projectRootFile;
+
+      programs = {
+        alejandra.enable = true; # nix formatter https://github.com/kamadorueda/alejandra
+        deadnix.enable = true; # removes dead nix code https://github.com/astro/deadnix
+        statix.enable = true; # prevents use of nix anti-patterns https://github.com/nerdypepper/statix
+        shellcheck.enable = true; # lints shell scripts https://github.com/koalaman/shellcheck
+      };
+    };
+
+    # configures treefmt as the program to use when invoke `nix fmt`
+    formatter = config.treefmt.build.wrapper;
+  };
+}

--- a/src/ghafscan/main.py
+++ b/src/ghafscan/main.py
@@ -252,7 +252,7 @@ class FlakeScanner:
         # due to github rate limits. If the execution time becomes a problem,
         # consider dropping the '--nixprs'
         out = self.tmpdir / "vulnxscan.csv"
-        cmd_vulnxscan = f"vulnxscan.py --triage --out={out}"
+        cmd_vulnxscan = f"vulnxscan --triage --out={out}"
         if buildtime:
             cmd_vulnxscan += " --buildtime"
         if nixprs:
@@ -514,7 +514,7 @@ class FlakeScanner:
             return
         cmd = f"{cmd} {str(drv_path)}"
         ret = exec_cmd(cmd.split())
-        LOG.debug("vulnxscan.py ==>\n\n%s\n\n<== vulnxscan.py\n", ret.stderr)
+        LOG.debug("vulnxscan ==>\n\n%s\n\n<== vulnxscan\n", ret.stderr)
         if not out_triage.exists():
             LOG.warning("vulnxscan triage output not found: %s", out_triage)
             return
@@ -583,7 +583,7 @@ def main():
     _set_log_verbosity(args.verbose)
     # Fail early if the following commands are not in PATH
     exit_unless_command_exists("nix")
-    exit_unless_command_exists("vulnxscan.py")
+    exit_unless_command_exists("vulnxscan")
     exit_unless_command_exists("csvdiff")
     scanner = FlakeScanner(args.flakeref)
     whitelist = args.whitelist


### PR DESCRIPTION
* introduces [flake.parts](https://flake.parts/) for a modular approach to composing the flake outputs
* configures [treefmt](https://github.com/numtide/treefmt-nix) for `nix fmt` which enables the following:
  * [alejandra](https://github.com/kamadorueda/alejandra) to format `.nix` files
  * [deadnix](https://github.com/astro/deadnix) to remove dead nix code
  * [statix](https://github.com/nerdypepper/statix) to avoid nix anti-patterns
  * [shellcheck](https://github.com/koalaman/shellcheck) to lint shell scripts
  * mixes in a flake check
* adds `reuse-lint` to check for copyright header issues when running `nix flake check`
* adds [flake-compat](https://github.com/nix-community/flake-compat) to ensure non-flake users can work with the repo and moves the devshell definition into the flake `devShells.default` output
* adds a `.envrc` file for [direnv](https://direnv.net/) users to automatically drop into the default dev shell when cd'ing into the repo
