### PR TITLE
Add scan orin NX builds

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -20,9 +20,9 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
     - name: Ghaf Vulnerability Scan (main)
-      run: nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/main --flakeref=github:tiiuae/ghaf?ref=main --target=packages.x86_64-linux.generic-x86_64-release --target=packages.riscv64-linux.microchip-icicle-kit-release
+      run: nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/main --flakeref=github:tiiuae/ghaf?ref=main --target=packages.x86_64-linux.generic-x86_64-release --target=packages.riscv64-linux.microchip-icicle-kit-release --target=packages.aarch64-linux.nvidia-jetson-orin-nx-release
     - name: Ghaf Vulnerability Scan (ghaf-24.03)
-      run: nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/ghaf-24.03 --flakeref=github:tiiuae/ghaf?ref=ghaf-24.03 --target=packages.x86_64-linux.generic-x86_64-release
+      run: nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/ghaf-24.03 --flakeref=github:tiiuae/ghaf?ref=ghaf-24.03 --target=packages.x86_64-linux.generic-x86_64-release --target=packages.aarch64-linux.nvidia-jetson-orin-nx-release
     - name: Ghaf Vulnerability Scan (ghaf-23.12)
       run: nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/ghaf-23.12 --flakeref=github:tiiuae/ghaf?ref=ghaf-23.12 --target=packages.x86_64-linux.generic-x86_64-release
     - uses: stefanzweifel/git-auto-commit-action@v4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ The Ghaf [vulnerability reports](./reports/) available on this repository are au
 ## Example Reports
 - [Ghaf 'main' generic-x86_64-release](./reports/main/packages.x86_64-linux.generic-x86_64-release.md)
 - [Ghaf 'main' riscv64-linux.microchip-icicle-kit-release](./reports/main/packages.riscv64-linux.microchip-icicle-kit-release.md)
+- [Ghaf 'main' aarch64-linux.nvidia-jetson-orin-nx-release](./reports/main/packages.aarch64-linux.nvidia-jetson-orin-nx-release.md)
 - [Ghaf 'ghaf-24.03' generic-x86_64-release](./reports/ghaf-24.03/packages.x86_64-linux.generic-x86_64-release.md)
+- [Ghaf 'ghaf-24.03' aarch64-linux.nvidia-jetson-orin-nx-release](./reports/ghaf-24.03/packages.aarch64-linux.nvidia-jetson-orin-nx-release.md)
 - [Ghaf 'ghaf-23.12' generic-x86_64-release](./reports/ghaf-23.12/packages.x86_64-linux.generic-x86_64-release.md)
 
 ## Motivation


### PR DESCRIPTION
Start scanning packages for aarch64-linux.nvidia-jetson-orin-nx-release as drone team is in the process of taking Ghaf Orin NX platform into use!

Reports should be available  in following branches main and  ghaf-24.03 after impulsive generated by the github action!

For examples
'main'  ./reports/main/packages.aarch64-linux.nvidia-jetson-orin-nx-release.md
'ghaf-24.03 ' ./reports/ghaf-24.03/packages.aarch64-linux.nvidia-jetson-orin-nx-release.md