### PR TITLE
Fix ghafscan after adding x1

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-name: Ghaf Vulnerability Scan 
+name: Ghaf Vulnerability Scan
 
 on:
   schedule:
@@ -15,8 +15,8 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v26
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
     - name: Ghaf Vulnerability Scan (main)

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -19,6 +19,11 @@ jobs:
     - uses: cachix/install-nix-action@v26
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
+        extra_nix_config: |
+          trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.vedenemo.dev:8NhplARANhClUSWJyLVk4WMyy1Wb4rhmWW2u8AejH9E= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://ghaf-dev.cachix.org?priority=20 https://cache.vedenemo.dev https://cache.nixos.org
+          connect-timeout = 5
+          system-features = nixos-test benchmark big-parallel kvm
     - name: Ghaf Vulnerability Scan (main)
       run: nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/main --flakeref=github:tiiuae/ghaf?ref=main --target=packages.x86_64-linux.lenovo-x1-carbon-gen11-release --target=packages.riscv64-linux.microchip-icicle-kit-release --target=packages.aarch64-linux.nvidia-jetson-orin-nx-release
     - name: Ghaf Vulnerability Scan (ghaf-24.03)


### PR DESCRIPTION
Fix automatic vulnerability scan after[ adding x1 targets](https://github.com/tiiuae/ghafscan/pull/15). Ghaf target `lenovo-x1-carbon-gen11-release` apparently builds a lot of packages already during evaluation. The builds do not pass in the 6-hour time limit set for the github-hosted builders, so the scheduled scans timed-out.

This PR modifies the scan workflow so it uses Ghaf binary caches in order to avoid re-building locally on the github builder. 