### PR TITLE
Replace reuse dep5 with REUSE.toml

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -1,5 +1,0 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-
-Copyright: 2023 Technology Innovation Institute (TII)
-License: Apache-2.0
-Files: *.lock *.png *.svg *.csv *.drawio VERSION

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2022-2025 TII (SSRC) and the Ghaf contributors
+# SPDX-License-Identifier: Apache-2.0
+
+version = 1
+SPDX-PackageName = "ghafscan"
+SPDX-PackageSupplier = "Technology Innovation Institute <https://tii.ae>"
+SPDX-PackageDownloadLocation = "https://github.com/tiiuae/ghafscan"
+
+[[annotations]]
+SPDX-License-Identifier = "Apache-2.0"
+SPDX-FileCopyrightText = "2022-2025 Technology Innovation Institute (TII)"
+precedence = "closest"
+path = [
+  "flake.lock",
+  "VERSION",
+  "**.csv",
+  "**.drawio",
+  "**.svg"
+]


### PR DESCRIPTION
Reuse dep5 is [deprecated](https://reuse.software/spec-3.2/#dep5-deprecated): replace reuse dep5 with [REUSE.toml](https://reuse.software/spec-3.2/#reusetoml)