### PR TITLE
Add scan target aarch64-linux.nvidia-jetson-orin-nx-debug

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -6,7 +6,7 @@ name: Ghaf Vulnerability Scan
 
 on:
   schedule:
-    - cron: "0 2 * * *"
+    - cron: "0 0 * * *"
   workflow_dispatch:
 
 permissions:
@@ -28,8 +28,8 @@ jobs:
       with:
         nix_path: nixpkgs=channel:nixpkgs-unstable
         extra_nix_config: |
-          trusted-public-keys = prod-cache.vedenemo.dev~1:JcytRNMJJdYJVQCYwLNsrfVhct5dhCK2D3fa6O1WHOI= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-          substituters = https://prod-cache.vedenemo.dev https://cache.nixos.org
+          trusted-public-keys = ghaf-dev.cachix.org-1:S3M8x3no8LFQPBfHw1jl6nmP8A7cVWKntoMKN3IsEQY= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+          substituters = https://ghaf-dev.cachix.org https://cache.nixos.org
           connect-timeout = 5
           system-features = nixos-test benchmark big-parallel kvm
     - name: Grype DB update
@@ -39,7 +39,7 @@ jobs:
         nix develop --command grype db status
     - name: Ghaf Vulnerability Scan (main)
       run: |
-        nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/main --flakeref=github:tiiuae/ghaf?ref=main --target=packages.x86_64-linux.lenovo-x1-carbon-gen11-debug
+        nix run .#ghafscan -- --verbose=2 --whitelist=manual_analysis.csv --outdir=reports/main --flakeref=github:tiiuae/ghaf?ref=main --target=packages.x86_64-linux.lenovo-x1-carbon-gen11-debug --target=packages.aarch64-linux.nvidia-jetson-orin-nx-debug
     - uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
       with:
         commit_message: Automatic vulnerability report update


### PR DESCRIPTION
- Add scan target aarch64-linux.nvidia-jetson-orin-nx-debug
- Update scan schedule: start two hours earlier
- Update nix substituters: replace `prod-cache.vedenemo.dev` with `ghaf-dev.cachix.org`