### PR TITLE
Scan buildtime depenencies

### DIFF
--- a/src/ghafscan/main.py
+++ b/src/ghafscan/main.py
@@ -598,9 +598,7 @@ def main():
         LOG.warning("Ignoring inaccessible whitelist: %s", whitelist.as_posix())
         whitelist = None
     for target in args.target:
-        scanner.scan_target(
-            target[0], buildtime=False, nixprs=True, whitelist=whitelist
-        )
+        scanner.scan_target(target[0], nixprs=True, whitelist=whitelist)
     scanner.report(args.outdir)
 
 


### PR DESCRIPTION
Revert the accidental change from https://github.com/tiiuae/ghafscan/pull/76 that set the `buildtime=False` in the `scan_target` call, that caused the scan to include only runtime dependencies. Getting the runtime-only dependencies in `nix` requires realising (building) the target, which doesn't work for Ghaf targets on the relatively modest github-hosted runners.

 